### PR TITLE
fixed an issue with group by in mysql 5.7

### DIFF
--- a/classes/class.SimpleChoiceQuestionStatistics.php
+++ b/classes/class.SimpleChoiceQuestionStatistics.php
@@ -312,7 +312,7 @@ class SimpleChoiceQuestionStatistics
 		 */
 		global $ilDB;
 		$res          = $ilDB->queryF(
-			'SELECT rep_robj_xvid_qus_text.answer_id, count(rep_robj_xvid_answers.answer_id) AS counter, answer, rep_robj_xvid_question.question_id FROM rep_robj_xvid_question
+			'SELECT count(rep_robj_xvid_answers.answer_id) AS counter FROM rep_robj_xvid_question
 				LEFT JOIN rep_robj_xvid_qus_text ON rep_robj_xvid_qus_text.question_id = rep_robj_xvid_question.question_id 
 				RIGHT JOIN rep_robj_xvid_answers ON rep_robj_xvid_qus_text.answer_id = rep_robj_xvid_answers.answer_id
 				WHERE  rep_robj_xvid_question.question_id = %s GROUP BY rep_robj_xvid_answers.answer_id',


### PR DESCRIPTION
MySQL 5.7 has now the standard setting ONLY_FULL_GROUP_BY activated which leads to DB error while saving answers of users