### PR TITLE
fixed handling of linked objects when removing object from trash

### DIFF
--- a/classes/class.ilObjInteractiveVideo.php
+++ b/classes/class.ilObjInteractiveVideo.php
@@ -306,16 +306,19 @@ class ilObjInteractiveVideo extends ilObjectPlugin implements ilLPStatusPluginIn
 	 */
 	public function beforeDelete()
 	{
-		$this->getVideoSourceObject($this->getSourceId());
-		$this->video_source_object->beforeDeleteVideoSource($this->getId());
-		self::deleteComments(self::getCommentIdsByObjId($this->getId(), false));
+        if ((!$this->referenced) || ($this->countReferences() == 1)) {
+            $this->getVideoSourceObject($this->getSourceId());
+            $this->video_source_object->beforeDeleteVideoSource($this->getId());
+            self::deleteComments(self::getCommentIdsByObjId($this->getId(), false));
 
-		/**
-		 * @var $ilDB ilDB
-		 */
-		global $ilDB;
-		$ilDB->manipulate('DELETE FROM ' . self::TABLE_NAME_OBJECTS . ' WHERE obj_id = ' . $ilDB->quote($this->getId(), 'integer'));
-		$this->deleteMetaData();
+            /**
+             * @var $ilDB ilDB
+             */
+            global $ilDB;
+            $ilDB->manipulate('DELETE FROM ' . self::TABLE_NAME_OBJECTS . ' WHERE obj_id = ' . $ilDB->quote($this->getId(), 'integer'));
+            $this->deleteMetaData();
+        }
+        return true;
 	}
 
 	/**


### PR DESCRIPTION
This fixes following bug:

1. Create InteractiveVideo anywhere
2. Link object somewhere else
3. Delete linked object
4. Remove linked object from trash
-> original object won't work anymore

So I added a reference check in the beforeDelete() method. Another (maybe nicer) solution would be to just move the logic to doDelete()