### PR TITLE
Hotfix/add lp rbac operations

### DIFF
--- a/classes/class.ilInteractiveVideoPlugin.php
+++ b/classes/class.ilInteractiveVideoPlugin.php
@@ -53,7 +53,33 @@ class ilInteractiveVideoPlugin extends ilRepositoryObjectPlugin
 		return self::$instance;
 	}
 
-	/**
+    protected function beforeActivation()
+    {
+        $return = parent::beforeActivation();
+
+        require_once 'Services/Migration/DBUpdate_3560/classes/class.ilDBUpdateNewObjectType.php';
+        $type = 'xvid';
+        $typeId = ilDBUpdateNewObjectType::getObjectTypeId($type);
+        $readLpOpsId = ilDBUpdateNewObjectType::getCustomRBACOperationId('read_learning_progress');
+        $editLpOpsId = ilDBUpdateNewObjectType::getCustomRBACOperationId('edit_learning_progress');
+        $writeOpsId = ilDBUpdateNewObjectType::getCustomRBACOperationId('write');
+        if ($readLpOpsId && $editLpOpsId && $writeOpsId) {
+            $readLpAdded = ilDBUpdateNewObjectType::addRBACOperation($typeId, $readLpOpsId);
+            $editLpAdded = ilDBUpdateNewObjectType::addRBACOperation($typeId, $editLpOpsId);
+            if ($readLpAdded) {
+                ilDBUpdateNewObjectType::cloneOperation($type, $writeOpsId, $readLpOpsId);
+            }
+
+            if ($editLpAdded) {
+                ilDBUpdateNewObjectType::cloneOperation($type, $writeOpsId, $editLpOpsId);
+            }
+        }
+
+        return $return;
+    }
+
+
+    /**
 	 * @return string
 	 */
 	public function getPluginName()

--- a/sql/dbupdate.php
+++ b/sql/dbupdate.php
@@ -868,13 +868,7 @@ if(!$ilDB->tableColumnExists('rep_robj_xvid_objects', 'no_comment'))
 ?>
 <#46>
 <?php
-require_once('./Services/Migration/DBUpdate_3560/classes/class.ilDBUpdateNewObjectType.php');
-$read_lp = ilDBUpdateNewObjectType::getCustomRBACOperationId('read_learning_progress');
-$xoct_type_id = ilDBUpdateNewObjectType::getObjectTypeId('xvid');
-
-if ($read_lp && $xoct_type_id) {
-	ilDBUpdateNewObjectType::addRBACOperation($xoct_type_id, $read_lp);
-}
+// Empty step
 ?>
 <#47>
 <?php


### PR DESCRIPTION
Adding `read_learning_progress` or/and `edit_learning_progress` during the database update steps may cause issues. Reason: The object type and it's supported RBAC operations are created in `ilRepositoryObjectPlugin::beforeActivation`.