### PR TITLE
fixIvMultiYoutube

### DIFF
--- a/VideoSources/core/Youtube/js/jquery.InteractiveVideoYoutubePlayer.js
+++ b/VideoSources/core/Youtube/js/jquery.InteractiveVideoYoutubePlayer.js
@@ -17,7 +17,9 @@ function onYouTubeIframeAPIReady() {
 	$.each(il.InteractiveVideo, function (player_id, value) {
 		if (value.hasOwnProperty("player_type") && value.player_type === "ytb") {
 			var player = new YT.Player(player_id, {
-				videoId:           interactiveVideoYoutubeId,
+				// fau: fixIvMultiYoutube - use data attribute instead of global variable
+				videoId:           $('#'+player_id).attr('data-youtube-id'),
+				// fau.
 				events:            {
 					'onStateChange': onPlayerStateChange,
 					'onReady':       function (media) {

--- a/VideoSources/core/Youtube/tpl/tpl.video.html
+++ b/VideoSources/core/Youtube/tpl/tpl.video.html
@@ -12,7 +12,6 @@
 		padding-top:15px;
 	}
 </style>
-<script>
-	var interactiveVideoYoutubeId = "{YOUTUBE_ID}";
-</script>
-<div id="{PLAYER_ID}"></div>
+<!-- fau: fixIvMultiYoutube - add youtube id as attribute instead of global js variable -->
+<div id="{PLAYER_ID}" data-youtube-id="{YOUTUBE_ID}"></div>
+<!-- fau. -->


### PR DESCRIPTION
Using the Plugin InteractiveVideoReference it is not possible to include two interactive videos with youtube as source on the same content page. The video of the second one will be used for the first one, too. Comments work independently for both.

see https://mantis.ilias.de/view.php?id=30288
