### PR TITLE
Corrected a few spelling mistakes

### DIFF
--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -33,7 +33,7 @@ post#:#Post
 cancel#:#Cancel
 sure_delete_comment#:#Are you sure, you want to delete the selected comments?
 missing_comment_text#:#Please enter a comment.
-missing_stopping_point#:#The stopping point was not trasnferred to the server. Please try again.
+missing_stopping_point#:#The stopping point was not transferred to the server. Please try again.
 invalid_comment_ids#:#Some comments could not be found.
 comments_successfully_deleted#:#The selected comments were deleted successfully.
 show_all_comments#:#Show all Comments:
@@ -100,7 +100,7 @@ already_answered#:#Question already answered.
 reflection#:#Reflective question
 answers#:#Answers
 sure_update_question#:#Are you sure, you want to save the question? Existing user results will be deleted! 
-question_type_info#:#You can choose between one of three avalibale quetsion types: a single choice, a multiple choice or a self-reflexion quertion. Self-reflexion questions do not have answer options and will be marked as "passed" once they have been shown to a user at least once.
+question_type_info#:#You can choose between one of three available question types: a single choice, a multiple choice or a self-reflexion question. Self-reflexion questions do not have answer options and will be marked as "passed" once they have been shown to a user at least once.
 is_jump_correct_info#:#In case the question was answered correctly, you can select a jump label (time stamp) within the video to which the user can jump using a button. This button will be shown along with the feedback text.
 is_jump_wrong_info#:#In case the question was answered incorrectly, you can select a jump label (time stamp) within the video to which the user can jump using a button. This button will be shown along with the feedback text.
 learning_recommendation#:#Learning recommendation within the video at

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -100,7 +100,7 @@ already_answered#:#Question already answered.
 reflection#:#Reflective question
 answers#:#Answers
 sure_update_question#:#Are you sure, you want to save the question? Existing user results will be deleted! 
-question_type_info#:#You can choose between one of three available question types: a single choice, a multiple choice or a self-reflexion question. Self-reflexion questions do not have answer options and will be marked as "passed" once they have been shown to a user at least once.
+question_type_info#:#You can choose between one of three available question types: a single choice, a multiple choice or a self-reflection question. Self-reflection questions do not have answer options and will be marked as "passed" once they have been shown to a user at least once.
 is_jump_correct_info#:#In case the question was answered correctly, you can select a jump label (time stamp) within the video to which the user can jump using a button. This button will be shown along with the feedback text.
 is_jump_wrong_info#:#In case the question was answered incorrectly, you can select a jump label (time stamp) within the video to which the user can jump using a button. This button will be shown along with the feedback text.
 learning_recommendation#:#Learning recommendation within the video at


### PR DESCRIPTION
Hello,

Thank you for this plugin. When testing it we noticed a few spelling mistakes in the help text. Corrections are in this pull request.

Screenshot:

![Screenshow of question help text with the spelling mistake](https://user-images.githubusercontent.com/7096681/110138274-a6a73e00-7d86-11eb-8592-a6404f81145f.png)
