### PR TITLE
fixup listgui

### DIFF
--- a/classes/class.ilObjInteractiveVideoListGUI.php
+++ b/classes/class.ilObjInteractiveVideoListGUI.php
@@ -25,11 +25,6 @@ class ilObjInteractiveVideoListGUI extends ilObjectPluginListGUI
 		return array
 		(
 			array(
-				'permission' => 'visible',
-				'cmd'        => 'showContent',
-				'default'    => true
-			),
-			array(
 				'permission' => 'read',
 				'cmd'        => 'showContent',
 				'default'    => true


### PR DESCRIPTION
Corrects the view in the magazine:
It should not be possible to call the object if only the visible right is set (= ILIAS default).