### PR TITLE
[FIX] missing called-by

### DIFF
--- a/classes/class.ilObjInteractiveVideoGUI.php
+++ b/classes/class.ilObjInteractiveVideoGUI.php
@@ -26,7 +26,7 @@ ilInteractiveVideoPlugin::getInstance()->includeClass('questions/class.SimpleCho
 /**
  * Class ilObjInteractiveVideoGUI
  * @author               Nadia Ahmad <nahmad@databay.de>
- * @ilCtrl_isCalledBy    ilObjInteractiveVideoGUI: ilRepositoryGUI, ilAdministrationGUI, ilObjPluginDispatchGUI
+ * @ilCtrl_isCalledBy    ilObjInteractiveVideoGUI: ilRepositoryGUI, ilAdministrationGUI, ilObjPluginDispatchGUI, ilContainerPageGUI
  * @ilCtrl_Calls         ilObjInteractiveVideoGUI: ilPermissionGUI, ilInfoScreenGUI, ilObjectCopyGUI, ilRepositorySearchGUI, ilPublicUserProfileGUI, ilCommonActionDispatcherGUI, ilMDEditorGUI
  * @ilCtrl_Calls         ilObjInteractiveVideoGUI: ilInteractiveVideoLearningProgressGUI
  * @ilCtrl_Calls         ilObjInteractiveVideoGUI: ilPropertyFormGUI


### PR DESCRIPTION
Hi! We always get an ilCtrl error when we want to embed a video via the Page Component plugin (InteractiveVideoReference). From my point of view, an isCalledBy error in the Interactive video. With this change, the whole thing works.