### PR TITLE
Added option to change the CSV export delimiter per InteractiveVideo item

### DIFF
--- a/classes/class.ilObjInteractiveVideo.php
+++ b/classes/class.ilObjInteractiveVideo.php
@@ -74,6 +74,11 @@ class ilObjInteractiveVideo extends ilObjectPlugin implements ilLPStatusPluginIn
 	 */
 	protected $fixed_modal = 0;
 
+    /**
+     * @var string
+     */
+    protected $csv_export_delimiter = ";";
+
 	/**
 	 * @var SimpleChoiceQuestion[]
 	 */
@@ -130,7 +135,7 @@ class ilObjInteractiveVideo extends ilObjectPlugin implements ilLPStatusPluginIn
 			array($this->getId())
 		);
 		$row = $ilDB->fetchAssoc($res);
-		
+
 		$this->setIsAnonymized($row['is_anonymized']);
 		$this->setIsRepeat($row['is_repeat']);
 		$this->setIsPublic($row['is_public']);
@@ -143,6 +148,7 @@ class ilObjInteractiveVideo extends ilObjectPlugin implements ilLPStatusPluginIn
 		$this->setDisableToolbar($row['no_toolbar']);
 		$this->setAutoResumeAfterQuestion($row['auto_resume']);
 		$this->setFixedModal($row['fixed_modal']);
+        $this->setCSVExportDelimiter($row['csv_export_delimiter']);
 		$this->setShowTocFirst($row['show_toc_first']);
 		$this->setDisableCommentStream($row['disable_comment_stream']);
 
@@ -299,6 +305,7 @@ class ilObjInteractiveVideo extends ilObjectPlugin implements ilLPStatusPluginIn
 						$no_toolbar		= $this->disable_toolbar;
 						$auto_resume	= $this->auto_resume_after_question;
 						$fixed_modal	= $this->fixed_modal;
+                        $csv_export_delimiter = $this->csv_export_delimiter;
 						$show_toc_first	= $this->show_toc_first;
 						$disable_comment_stream	= $this->disable_comment_stream;
 					}
@@ -315,6 +322,7 @@ class ilObjInteractiveVideo extends ilObjectPlugin implements ilLPStatusPluginIn
 						$no_toolbar		= (int)$_POST['no_toolbar'];
 						$auto_resume	= (int)$_POST['auto_resume'];
 						$fixed_modal	= (int)$_POST['fixed_modal'];
+                        $csv_export_delimiter = ilUtil::stripSlashes($_POST['csv_export_delimiter']);
 						$show_toc_first	= (int)$_POST['show_toc_first'];
 						$disable_comment_stream	= (int)$_POST['disable_comment_stream'];
 					}
@@ -332,6 +340,7 @@ class ilObjInteractiveVideo extends ilObjectPlugin implements ilLPStatusPluginIn
 							'is_task'        => array('integer',$is_task ),
 							'auto_resume'    => array('integer',$auto_resume ),
 							'fixed_modal'    => array('integer',$fixed_modal ),
+                            'csv_export_delimiter' => array('text', ";"),
 							'task'           => array('text', $task),
 							'no_comment'     => array('integer', $no_comment),
 							'no_toolbar'     => array('integer', $no_toolbar),
@@ -373,7 +382,7 @@ class ilObjInteractiveVideo extends ilObjectPlugin implements ilLPStatusPluginIn
 		global $ilDB;
 
 		parent::doUpdate();
-		
+
 		$old_source_id = $this->getOldVideoSource();
 		if($old_source_id != null && $old_source_id != $this->getSourceId())
 		{
@@ -389,12 +398,13 @@ class ilObjInteractiveVideo extends ilObjectPlugin implements ilLPStatusPluginIn
 					'is_online'			=>array('integer',	$this->isOnline()),
 					'source_id'			=>array('text',		$this->getSourceId()),
 					'is_task'			=> array('integer', $this->getTaskActive()),
-					'task'				=> array('text',	$this->getTask()), 
+					'task'				=> array('text',	$this->getTask()),
 					'auto_resume'       => array('integer', $this->isAutoResumeAfterQuestion()),
 					'fixed_modal'       => array('integer', $this->isFixedModal()),
+                    'csv_export_delimiter' => array('text', $this->getCSVExportDelimiter()),
 					'show_toc_first'    => array('integer', $this->getShowTocFirst()),
 					'disable_comment_stream'    => array('integer', $this->getDisableCommentStream()),
-					'lp_mode'			=> array('integer', $this->getLearningProgressMode()), 
+					'lp_mode'			=> array('integer', $this->getLearningProgressMode()),
 					'no_comment'		=> array('integer', $this->getDisableComment()),
 					'no_toolbar'		=> array('integer', $this->getDisableToolbar())
 					),
@@ -463,6 +473,7 @@ class ilObjInteractiveVideo extends ilObjectPlugin implements ilLPStatusPluginIn
 				'task'     => array('text', $this->getTask()),
 				'auto_resume'     => array('integer', $this->isAutoResumeAfterQuestion()),
 				'fixed_modal'     => array('integer', $this->isFixedModal()),
+                'csv_export_delimiter' => array('text', $this->getCSVExportDelimiter()),
 				'show_toc_first'  => array('integer', $this->getShowTocFirst()),
 				'disable_comment_stream'  => array('integer', $this->getDisableCommentStream()),
 				'lp_mode' => array('integer', $this->getLearningProgressMode())
@@ -1385,6 +1396,22 @@ class ilObjInteractiveVideo extends ilObjectPlugin implements ilLPStatusPluginIn
 	{
 		$this->fixed_modal = $fixed_modal;
 	}
+
+    /**
+     * @return string
+     */
+    public function getCSVExportDelimiter()
+    {
+        return $this->csv_export_delimiter;
+    }
+
+    /**
+     * @param string $csv_export_delimiter
+     */
+    public function setCSVExportDelimiter($csv_export_delimiter)
+    {
+        $this->csv_export_delimiter = $csv_export_delimiter;
+    }
 
     /**
      * @return int

--- a/classes/class.ilObjInteractiveVideo.php
+++ b/classes/class.ilObjInteractiveVideo.php
@@ -74,10 +74,10 @@ class ilObjInteractiveVideo extends ilObjectPlugin implements ilLPStatusPluginIn
 	 */
 	protected $fixed_modal = 0;
 
-    /**
-     * @var string
-     */
-    protected $csv_export_delimiter = ";";
+	/**
+	 * @var string
+	 */
+	protected $csv_export_delimiter = ";";
 
 	/**
 	 * @var SimpleChoiceQuestion[]
@@ -148,7 +148,7 @@ class ilObjInteractiveVideo extends ilObjectPlugin implements ilLPStatusPluginIn
 		$this->setDisableToolbar($row['no_toolbar']);
 		$this->setAutoResumeAfterQuestion($row['auto_resume']);
 		$this->setFixedModal($row['fixed_modal']);
-        $this->setCSVExportDelimiter($row['csv_export_delimiter']);
+		$this->setCSVExportDelimiter($row['csv_export_delimiter']);
 		$this->setShowTocFirst($row['show_toc_first']);
 		$this->setDisableCommentStream($row['disable_comment_stream']);
 
@@ -305,7 +305,6 @@ class ilObjInteractiveVideo extends ilObjectPlugin implements ilLPStatusPluginIn
 						$no_toolbar		= $this->disable_toolbar;
 						$auto_resume	= $this->auto_resume_after_question;
 						$fixed_modal	= $this->fixed_modal;
-                        $csv_export_delimiter = $this->csv_export_delimiter;
 						$show_toc_first	= $this->show_toc_first;
 						$disable_comment_stream	= $this->disable_comment_stream;
 					}
@@ -322,7 +321,6 @@ class ilObjInteractiveVideo extends ilObjectPlugin implements ilLPStatusPluginIn
 						$no_toolbar		= (int)$_POST['no_toolbar'];
 						$auto_resume	= (int)$_POST['auto_resume'];
 						$fixed_modal	= (int)$_POST['fixed_modal'];
-                        $csv_export_delimiter = ilUtil::stripSlashes($_POST['csv_export_delimiter']);
 						$show_toc_first	= (int)$_POST['show_toc_first'];
 						$disable_comment_stream	= (int)$_POST['disable_comment_stream'];
 					}
@@ -340,7 +338,7 @@ class ilObjInteractiveVideo extends ilObjectPlugin implements ilLPStatusPluginIn
 							'is_task'        => array('integer',$is_task ),
 							'auto_resume'    => array('integer',$auto_resume ),
 							'fixed_modal'    => array('integer',$fixed_modal ),
-                            'csv_export_delimiter' => array('text', ";"),
+							'csv_export_delimiter' => array('text', ";"),
 							'task'           => array('text', $task),
 							'no_comment'     => array('integer', $no_comment),
 							'no_toolbar'     => array('integer', $no_toolbar),
@@ -401,7 +399,7 @@ class ilObjInteractiveVideo extends ilObjectPlugin implements ilLPStatusPluginIn
 					'task'				=> array('text',	$this->getTask()),
 					'auto_resume'       => array('integer', $this->isAutoResumeAfterQuestion()),
 					'fixed_modal'       => array('integer', $this->isFixedModal()),
-                    'csv_export_delimiter' => array('text', $this->getCSVExportDelimiter()),
+					'csv_export_delimiter' => array('text', $this->getCSVExportDelimiter()),
 					'show_toc_first'    => array('integer', $this->getShowTocFirst()),
 					'disable_comment_stream'    => array('integer', $this->getDisableCommentStream()),
 					'lp_mode'			=> array('integer', $this->getLearningProgressMode()),
@@ -473,7 +471,7 @@ class ilObjInteractiveVideo extends ilObjectPlugin implements ilLPStatusPluginIn
 				'task'     => array('text', $this->getTask()),
 				'auto_resume'     => array('integer', $this->isAutoResumeAfterQuestion()),
 				'fixed_modal'     => array('integer', $this->isFixedModal()),
-                'csv_export_delimiter' => array('text', $this->getCSVExportDelimiter()),
+				'csv_export_delimiter' => array('text', $this->getCSVExportDelimiter()),
 				'show_toc_first'  => array('integer', $this->getShowTocFirst()),
 				'disable_comment_stream'  => array('integer', $this->getDisableCommentStream()),
 				'lp_mode' => array('integer', $this->getLearningProgressMode())
@@ -1397,21 +1395,21 @@ class ilObjInteractiveVideo extends ilObjectPlugin implements ilLPStatusPluginIn
 		$this->fixed_modal = $fixed_modal;
 	}
 
-    /**
-     * @return string
-     */
-    public function getCSVExportDelimiter()
-    {
-        return $this->csv_export_delimiter;
-    }
+	/**
+	 * @return string
+	 */
+	public function getCSVExportDelimiter()
+	{
+		return $this->csv_export_delimiter;
+	}
 
-    /**
-     * @param string $csv_export_delimiter
-     */
-    public function setCSVExportDelimiter($csv_export_delimiter)
-    {
-        $this->csv_export_delimiter = $csv_export_delimiter;
-    }
+	/**
+	 * @param string $csv_export_delimiter
+	 */
+	public function setCSVExportDelimiter($csv_export_delimiter)
+	{
+		$this->csv_export_delimiter = $csv_export_delimiter;
+	}
 
     /**
      * @return int

--- a/classes/class.ilObjInteractiveVideoGUI.php
+++ b/classes/class.ilObjInteractiveVideoGUI.php
@@ -34,7 +34,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 
 	/** @var ilObjInteractiveVideo $object */
 	public $object;
-	
+
 	/** @var $objComment ilObjComment */
 	public $objComment;
 
@@ -182,16 +182,16 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 						}
 						else  $this->editComments();
 						break;
-					
+
 					case 'updateProperties':
 					case 'editProperties':
 					case 'addSubtitle':
 					case 'postAddSubtitle':
 					case 'confirmDeleteComment':
 					case 'confirmRemoveSubtitle':
-					case 'deleteComment': 
-					case 'editComments':  
-				    case 'editQuestion': 
+					case 'deleteComment':
+					case 'editComments':
+				    case 'editQuestion':
 					case 'confirmUpdateQuestion':
 				    case 'insertQuestion':
                     case 'completeCsvExport':
@@ -542,7 +542,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 		$mathJaxSetting = new ilSetting('MathJax');
 		if($mathJaxSetting->get('enable'))
 		{
-			
+
 			$tpl->addJavaScript($mathJaxSetting->get('path_to_mathjax'));
 			$ck_editor->setVariable('MATH_JAX_CONFIG', $mathJaxSetting->get('path_to_mathjax'));
 		}
@@ -649,6 +649,9 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 
 		$fixed_modal = $a_form->getInput('fixed_modal');
 		$this->object->setFixedModal((int)$fixed_modal);
+
+        $csv_export_delimiter = $a_form->getInput('csv_export_delimiter');
+        $this->object->setCSVExportDelimiter(ilUtil::stripSlashes($csv_export_delimiter));
 
 		$factory = new ilInteractiveVideoSourceFactory();
 		$source = $factory->getVideoSourceObject($a_form->getInput('source_id'));
@@ -814,6 +817,15 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 		$fixed_modal->setInfo($plugin->txt('fixed_modal_info'));
 		$fixed_modal->setValue(1);
 		$a_form->addItem($fixed_modal);
+
+        $section = new ilFormSectionHeaderGUI();
+        $section->setTitle($plugin->txt('export_section'));
+        $a_form->addItem($section);
+
+        $csv_export_delimiter = new ilTextInputGUI($plugin->txt('csv_export_delimiter'), 'csv_export_delimiter');
+        $csv_export_delimiter->setInfo($plugin->txt('csv_export_delimiter_info'));
+        $csv_export_delimiter->setValue(";");
+        $a_form->addItem($csv_export_delimiter);
 	}
 
 	/**
@@ -851,6 +863,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 		$a_values['task']				= $this->object->getTask();
 		$a_values['auto_resume']		= $this->object->isAutoResumeAfterQuestion();
 		$a_values['fixed_modal']		= $this->object->isFixedModal();
+        $a_values['csv_export_delimiter'] = $this->object->getCSVExportDelimiter();
 	}
 
 	public function editProperties()
@@ -908,7 +921,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 		$form->setTarget("_top");
 		$form->setFormAction($ilCtrl->getFormAction($this, "update"));
 		$form->setTitle($this->plugin->txt("subtitle"));
-		
+
 		$file = new ilFileInputGUI($this->plugin->txt('subtitle'), 'subtitle');
 		$file->setSuffixes(array('vtt'));
 		$form->addItem($file);
@@ -990,7 +1003,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 			$this->object->removeSubtitleData($filename);
 			ilUtil::sendSuccess($this->plugin->txt('subtitle_removed'), true);
 			$this->ctrl->redirect($this, 'addSubtitle');
-			
+
 		}
 
 	}
@@ -1040,7 +1053,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 			{
 				chmod($new_file, 0770);
 			}
-		
+
 		}
 		$data_short = array();
 		$data_long  = array();
@@ -1059,7 +1072,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 			}
 		}
 		$this->object->saveSubtitleData($data_short, $data_long);
-		
+
 		$this->addSubtitle();
 	}
 
@@ -1138,7 +1151,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 		$plugin = ilInteractiveVideoPlugin::getInstance();
 		$factory = new ilInteractiveVideoSourceFactory();
 		$sources = $factory->getVideoSources();
-		
+
 		$item_group = new ilRadioGroupInputGUI($plugin->txt('source'), 'source_id');
 		$a_form->addItem($item_group);
 		$non_active = true;
@@ -1243,7 +1256,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 				}
 			}
 		}
-		
+
 		if($ilAccess->checkAccess('write', '', $this->object->getRefId()))
 		{
 			$ilTabs->addTab('editComments', ilInteractiveVideoPlugin::getInstance()->txt('questions_comments'), $this->ctrl->getLinkTarget($this, 'editComments'));
@@ -1307,7 +1320,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 				}
 				$ilTabs->addSubTab('editMyComments', $plugin->txt('my_comments'),$this->ctrl->getLinkTarget($this,'editMyComments'));
 				$ilTabs->addSubTab('showMyResults', $plugin->txt('show_my_results'), $this->ctrl->getLinkTarget($this, 'showMyResults'));
-				
+
 				if($ilAccess->checkAccess('write', '', $this->object->getRefId()))
 				{
 					$ilTabs->addSubTab('showResults', $plugin->txt('user_results'), $this->ctrl->getLinkTarget($this, 'showResults'));
@@ -1407,7 +1420,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 		$comment->setCommentTime((float)$_POST['comment_time']);
 		$comment->setIsTableOfContent((int)$_POST['is_table_of_content']);
 		$comment->setCommentTimeEnd($seconds_end);
-		
+
 		if(array_key_exists('is_reply_to', $_POST))
 		{
 			$comment->setIsReplyTo((int) $_POST['is_reply_to']);
@@ -1533,7 +1546,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 
 		$title = new ilTextInputGUI($this->lng->txt('title'), 'comment_title');
 		$form->addItem($title);
-		
+
 		$time = new ilInteractiveVideoTimePicker($this->lng->txt('time'), 'comment_time');
 		#$time->setShowTime(true);
 		#$time->setShowSeconds(true);
@@ -2175,7 +2188,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
      * @throws ilTemplateException
      */
 	private function getCommentFormValues($comment_id = 0)
-	{		
+	{
 	    $values = array();
 		if($comment_id == 0)
 		{
@@ -2258,7 +2271,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 		$title->setInfo($plugin->txt('comment_title_info'));
 		$title->setRequired(true);
 		$form->addItem($title);
-		
+
 		$time = new ilInteractiveVideoTimePicker($this->lng->txt('time'), 'comment_time');
 
 		if(isset($_POST['comment_time']))
@@ -2302,7 +2315,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 		$neutral_type->setOptions($neutral_type_options);
 		$neutral_type->setInfo($plugin->txt('neutral_type_info'));
 		$form->addItem($neutral_type);
-		
+
 
 		$answer = new ilCustomInputGUI($this->lng->txt('answers'), 'answer_text');
 		$answer->setHtml($this->getInteractiveForm());
@@ -2609,7 +2622,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 			$confirm->setConfirm($this->lng->txt('update'), 'updateQuestion');
 			foreach($_POST as $key=>$value)
 			{
-				//@todo .... very quick ... very dirty .... 
+				//@todo .... very quick ... very dirty ....
 				if($key != 'cmd')
 				{
 					$form_values[$key] = $value;
@@ -2629,7 +2642,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 		$form = $this->initQuestionForm();
 		if(isset($_POST['form_values']))
 		{
-			//@todo .... very quick ... very wtf .... 
+			//@todo .... very quick ... very wtf ....
 			$_POST = unserialize($_POST['form_values']);
 			$_FILES = unserialize($_REQUEST['form_files']);
 		}
@@ -2686,7 +2699,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 			ilInteractiveVideoFFmpeg::removeSelectedImage($question->getQuestionImage());
 			$question->setQuestionImage(null);
 		}
-		
+
 		$question->setQuestionText(ilUtil::stripSlashes($form->getInput('question_text'), false));
 		$question->setFeedbackCorrect(ilUtil::stripSlashes($form->getInput('feedback_correct'), false));
 		$question->setFeedbackOneWrong(ilUtil::stripSlashes($form->getInput('feedback_one_wrong'), false));
@@ -2696,7 +2709,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 		$question->setShowCorrectIcon((int)$form->getInput('show_correct_icon'));
 		$question->setFeedbackCorrectId((int)$form->getInput('feedback_correct_obj'));
 		$question->setFeedbackWrongId((int)$form->getInput('feedback_wrong_obj'));
-		
+
 		$question->setJumpCorrectTs((int) $form->getInput('jump_correct_ts'));
 
 		$question->setIsJumpWrong((int)$form->getInput('is_jump_wrong'));
@@ -3020,7 +3033,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 	}
 
 	/**
-	 * 
+	 *
 	 */
 	public function generateThumbnailsFromSourcePerAjax()
 	{
@@ -3050,7 +3063,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 				$tpl_json->setVariable('JSON', json_encode(array('error' => $e->getMessage())));
 				$tpl_json->show("DEFAULT", false, true);
 			}
-		
+
 
 		}
 		$this->callExit();
@@ -3085,7 +3098,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 
 		$this->callExit();
 	}
-	
+
 	protected function callExit()
 	{
 		exit();
@@ -3106,7 +3119,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 		$data = $simple->getScoreForAllQuestionsAndAllUser($this->obj_id);
 
 		$csv = array();
-		$separator = ";";
+		$separator = $this->object->getCSVExportDelimiter();
 
 		$head_row = array();
 		array_push($head_row, $lng->txt('name'));
@@ -3155,7 +3168,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 		$data = $this->object->getCommentsTableDataByUserId();
 
 		$csv = array();
-		$separator = ";";
+		$separator = $this->object->getCSVExportDelimiter();
 
 		$head_row = array();
 		array_push($head_row, $lng->txt('id'));
@@ -3163,6 +3176,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 		array_push($head_row, $plugin->txt('time_end') );
 		array_push($head_row, $plugin->txt('comment_title'));
 		array_push($head_row, $plugin->txt('comment'));
+        array_push($head_row, $plugin->txt('compulsory'));
 		array_push($head_row, $plugin->txt('visibility'));
 		array_push($csv, ilUtil::processCSVRow($head_row, TRUE, $separator) );
 		foreach ($data as $key => $row)
@@ -3193,7 +3207,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 		$data = $this->object->getCommentsTableData(true, false, false, true);
 
 		$csv = array();
-		$separator = ";";
+		$separator = $this->object->getCSVExportDelimiter();
 
 		$head_row = array();
 
@@ -3206,6 +3220,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 		array_push($head_row, $plugin->txt('tutor'));
 		array_push($head_row, $plugin->txt('interactive'));
 		array_push($head_row, $plugin->txt('compulsory'));
+        array_push($head_row, $plugin->txt('is_table_of_content'));
 		array_push($head_row, $plugin->txt('type'));
 
 		array_push($csv, ilUtil::processCSVRow($head_row, TRUE, $separator) );
@@ -3233,7 +3248,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 	{
 		/**
 		 * @var $ilCtrl ilCtrl
-		 * @var $ilAccess ilAccessHandler 
+		 * @var $ilAccess ilAccessHandler
 		 */
 		global $ilCtrl, $ilAccess, $lng;
 

--- a/classes/class.ilObjInteractiveVideoGUI.php
+++ b/classes/class.ilObjInteractiveVideoGUI.php
@@ -650,8 +650,8 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 		$fixed_modal = $a_form->getInput('fixed_modal');
 		$this->object->setFixedModal((int)$fixed_modal);
 
-        $csv_export_delimiter = $a_form->getInput('csv_export_delimiter');
-        $this->object->setCSVExportDelimiter(ilUtil::stripSlashes($csv_export_delimiter));
+		$csv_export_delimiter = $a_form->getInput('csv_export_delimiter');
+		$this->object->setCSVExportDelimiter(ilUtil::stripSlashes($csv_export_delimiter));
 
 		$factory = new ilInteractiveVideoSourceFactory();
 		$source = $factory->getVideoSourceObject($a_form->getInput('source_id'));
@@ -818,14 +818,14 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 		$fixed_modal->setValue(1);
 		$a_form->addItem($fixed_modal);
 
-        $section = new ilFormSectionHeaderGUI();
-        $section->setTitle($plugin->txt('export_section'));
-        $a_form->addItem($section);
+		$section = new ilFormSectionHeaderGUI();
+		$section->setTitle($plugin->txt('export_section'));
+		$a_form->addItem($section);
 
-        $csv_export_delimiter = new ilTextInputGUI($plugin->txt('csv_export_delimiter'), 'csv_export_delimiter');
-        $csv_export_delimiter->setInfo($plugin->txt('csv_export_delimiter_info'));
-        $csv_export_delimiter->setValue(";");
-        $a_form->addItem($csv_export_delimiter);
+		$csv_export_delimiter = new ilTextInputGUI($plugin->txt('csv_export_delimiter'), 'csv_export_delimiter');
+		$csv_export_delimiter->setInfo($plugin->txt('csv_export_delimiter_info'));
+		$csv_export_delimiter->setValue(";");
+		$a_form->addItem($csv_export_delimiter);
 	}
 
 	/**
@@ -863,7 +863,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 		$a_values['task']				= $this->object->getTask();
 		$a_values['auto_resume']		= $this->object->isAutoResumeAfterQuestion();
 		$a_values['fixed_modal']		= $this->object->isFixedModal();
-        $a_values['csv_export_delimiter'] = $this->object->getCSVExportDelimiter();
+		$a_values['csv_export_delimiter'] = $this->object->getCSVExportDelimiter();
 	}
 
 	public function editProperties()
@@ -3176,7 +3176,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 		array_push($head_row, $plugin->txt('time_end') );
 		array_push($head_row, $plugin->txt('comment_title'));
 		array_push($head_row, $plugin->txt('comment'));
-        array_push($head_row, $plugin->txt('compulsory'));
+		array_push($head_row, $plugin->txt('compulsory'));
 		array_push($head_row, $plugin->txt('visibility'));
 		array_push($csv, ilUtil::processCSVRow($head_row, TRUE, $separator) );
 		foreach ($data as $key => $row)
@@ -3220,7 +3220,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 		array_push($head_row, $plugin->txt('tutor'));
 		array_push($head_row, $plugin->txt('interactive'));
 		array_push($head_row, $plugin->txt('compulsory'));
-        array_push($head_row, $plugin->txt('is_table_of_content'));
+		array_push($head_row, $plugin->txt('is_table_of_content'));
 		array_push($head_row, $plugin->txt('type'));
 
 		array_push($csv, ilUtil::processCSVRow($head_row, TRUE, $separator) );

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -14,7 +14,7 @@ xvid_visible#:#Interaktives Video ist sichtbar
 xvid_read_learning_progress#:#Benutzer kann Lernfortschritt anderer Benutzer einsehen
 xvid_edit_learning_progress#:#Benutzer kann Lernfortschritt Einstellungen bearbeiten
 reset#:#Zurücksetzen
-show_all_comments#:#Alle Kommentare anzeigen: 
+show_all_comments#:#Alle Kommentare anzeigen:
 author_filter#:#Autorenfilter
 crs_create_xvid#:#Neues Interaktives Video anlegen
 grp_create_xvid#:#Neues Interaktives Video anlegen
@@ -35,7 +35,7 @@ cancel#:#Abbrechen
 sure_delete_comment#:#Sind Sie sicher, dass Sie den gewählten Kommentare/Fragen/Kapitel löschen möchten?
 missing_comment_text#:#Bitte geben Sie einen Kommentar ein.
 missing_stopping_point#:#Der Haltepunkt wurde nicht zum Server übertragen. Bitte versuchen Sie es erneut.
-invalid_comment_ids#:#Einige Kommentare konnten nicht gefunden werden. 
+invalid_comment_ids#:#Einige Kommentare konnten nicht gefunden werden.
 comments_successfully_deleted#:#Die gewählten Kommentare wurden erfolgreich gelöscht.
 insert_comment#:#Neue Frage / Neuen Kommentar einfügen
 edit_comment#:#Kommentar bearbeiten
@@ -126,7 +126,7 @@ crs_create_xvid#:#Interaktives Video anlegen
 cat_create_xvid#:#Interaktives Video anlegen
 root_create_xvid#:#Interaktives Video anlegen
 fold_create_xvid#:#Interaktives Video anlegen
-rbac_create_xvid#:#Interaktives Video anlegen 
+rbac_create_xvid#:#Interaktives Video anlegen
 source#:#Quelle
 installed_version#:#Installierte Databank Version: %s, Datei Datenbank Version %s
 source_does_not_exist#:#Quelle existiert nicht mehr oder wurde in der Administration deaktiviert
@@ -173,7 +173,7 @@ export_all_comments#:#Alle Kommentare exportieren
 question_image#:#Bild für Frage
 extract#:#Thumbnail aus Video erzeugen
 use_this_image#:#Dieses Bild verwenden
-time_for_preview#:#Zeitpunkt: 
+time_for_preview#:#Zeitpunkt:
 comment_title_info#:#Der Titel wird im Kommentarstream angezeigt und ist für die Kursteilnehmer damit immer sichtbar.
 correct_answer#:#Richtig
 wrong_answer#:#Falsch
@@ -220,3 +220,6 @@ best_solution_text#:#Bestmögliche Lösung
 best_solution_text_info#:#Wenn ein Kommentarfeld angeboten wird (siehe unten), kann sich ein Nutzer die Lösung erst anzeigen lassen, wenn er/sie eine Antwort gespeichert hat.
 show_best_solution_info#:#Nachdem die Frage beantwortet wurde, können sich Nutzer die richtige Lösung anzeigen lassen (über Button «Lösung zeigen»).
 at_least_one_answer#:#Bitte wählen Sie eine Antwort aus
+export_section#:#Export
+csv_export_delimiter#:#CSV-Exporttrennzeichen
+csv_export_delimiter_info#:#Ändern Sie das Standardtrennzeichen für CSV-Exporte.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -80,7 +80,7 @@ send#:#Check
 close#:#Close
 question#:#Question
 is_anonymized#:#Anonymize Comments
-is_anonymized_info#:#If enabled all comments are shown without usernames 
+is_anonymized_info#:#If enabled all comments are shown without usernames
 is_public#:#Publish All Comments
 is_public_info#:#"If enabled all users are able to read all PUBLIC comments. Otherwise they are only able to see own comments and public comments created by administrators (in the tab "Questions, chapters and comments")
 correct_answered#:#Answered correctly
@@ -100,7 +100,7 @@ feedback#:#Feedback
 already_answered#:#Question already answered.
 reflection#:#Reflective question
 answers#:#Answers
-sure_update_question#:#Are you sure, you want to save the question? Existing user results will be deleted! 
+sure_update_question#:#Are you sure, you want to save the question? Existing user results will be deleted!
 question_type_info#:#You can choose between one of three available question types: a single choice, a multiple choice or a self-reflexion quertion. Self-reflexion questions do not have answer options and will be marked as "passed" once they have been shown to a user at least once.
 is_jump_correct_info#:#In case the question was answered correctly, you can select a jump label (time stamp) within the video to which the user can jump using a button. This button will be shown along with the feedback text.
 is_jump_wrong_info#:#In case the question was answered incorrectly, you can select a jump label (time stamp) within the video to which the user can jump using a button. This button will be shown along with the feedback text.
@@ -128,7 +128,7 @@ crs_create_xvid#:#Create Interactive Video
 cat_create_xvid#:#Create Interactive Video
 root_create_xvid#:#Create Interactive Video
 fold_create_xvid#:#Create Interactive Video
-rbac_create_xvid#:#Create Interactive Video 
+rbac_create_xvid#:#Create Interactive Video
 source#:#Source
 installed_version#:#Installed Database Version: %s, File Database Version %s
 source_does_not_exist#:#Source does not exist anymore or was disabled in the administration
@@ -175,7 +175,7 @@ export_all_comments#:#Export All Comments
 question_image#:#Question image
 extract#:#Generate Thumbnail from Video
 use_this_image#:#Use this image
-time_for_preview#:#Time: 
+time_for_preview#:#Time:
 comment_title_info#:#The title is always visible in the comment screen.
 correct_answer#:#Correct
 wrong_answer#:#Wrong
@@ -190,7 +190,7 @@ no_comment_info#:#There will be no comment field below the video player
 xvid_xvid_view_lp#:#View Learning Progress
 auto_resume#:#Auto resume
 auto_resume_info#:#If enabled, the video will be automatically resumed after closing a the modal question dialogue.
-fixed_modal#:#Block modal closing 
+fixed_modal#:#Block modal closing
 fixed_modal_info#:#If enabled, a modal dialogue won't be closed if a user clicks on the background.
 modal_section#:#Behaviour of Question Dialogue
 subtitle#:#Subtitle
@@ -221,3 +221,6 @@ best_solution_text#:#Best solution
 best_solution_text_info#:#If a comment field is offered (see below), a user cannot view the solution until he/she has saved an answer.
 show_best_solution_info#:#After answering the question, users can display the correct solution (via button "Show solution").
 at_least_one_answer#:#Please select an answer
+export_section#:#Export
+csv_export_delimiter#:#CSV export delimiter
+csv_export_delimiter_info#:#Change the default delimiter for CSV exports.

--- a/lang/ilias_it.lang
+++ b/lang/ilias_it.lang
@@ -99,7 +99,7 @@ feedback#:#Feedback
 already_answered#:#Domanda già risposta.
 reflection#:#Domanda riflessiva
 answers#:#Risposte
-sure_update_question#:#Sei sicuro di voler salvare la domanda? I risultati utente esistenti verranno eliminati! 
+sure_update_question#:#Sei sicuro di voler salvare la domanda? I risultati utente esistenti verranno eliminati!
 question_type_info#:#Puoi scegliere tra uno dei tre tipi di domande disponibili: a scelta singola, a risposta multipla o riflessiva. Le domande riflessive non hanno opzioni di risposta e saranno contrassegnate come "superate" una volta che sono state mostrate a un utente almeno una volta.
 is_jump_correct_info#:#Nel caso in cui la risposta alla domanda sia stata corretta, è possibile selezionare un'etichetta per saltare (time stamp) all'interno del video utilizzando un pulsante. Questo pulsante verrà mostrato insieme al testo di feedback.
 is_jump_wrong_info#:#Nel caso in cui alla domanda sia stata data una risposta errata, è possibile selezionare un'etichetta per saltare (time stamp) all'interno del video utilizzando un pulsante. Questo pulsante verrà mostrato insieme al testo di feedback.
@@ -174,7 +174,7 @@ export_all_comments#:#Esporta tutti i commenti
 question_image#:#Domanda immagine
 extract#:#Genera thumbnail dal video
 use_this_image#:#Usa questa immagine
-time_for_preview#:#Tempo: 
+time_for_preview#:#Tempo:
 comment_title_info#:#Il titolo è sempre visibile nella schermata dei commenti.
 correct_answer#:#Corretto
 wrong_answer#:#Sbagliato
@@ -189,7 +189,7 @@ no_comment_info#:#Non ci sarà nessun campo di commento sotto il video player
 xvid_xvid_view_lp#:#Visualizza i progressi di apprendimento
 auto_resume#:#Ripristino automatico
 auto_resume_info#:#Se abilitato, il video verrà ripreso automaticamente dopo aver chiuso una finestra di dialogo della domanda modale.
-fixed_modal#:#Blocco chiusura modale 
+fixed_modal#:#Blocco chiusura modale
 fixed_modal_info#:#Se abilitato, un dialogo modale non verrà chiuso se un utente fa clic sullo sfondo.
 modal_section#:#Dialogo sul comportamento delle domande
 subtitle#:#Sottotitolo
@@ -220,3 +220,6 @@ best_solution_text#:#Soluzione migliore
 best_solution_text_info#:#Se viene offerto un campo di commento (vedi sotto), un utente non può visualizzare la soluzione finché non ha salvato una risposta.
 show_best_solution_info#:#Dopo aver risposto alla domanda, gli utenti possono visualizzare la soluzione corretta (tramite il pulsante "Mostra soluzione").
 at_least_one_answer#:#Seleziona una risposta
+export_section#:#Eksportuoti
+csv_export_delimiter#:#Delimitatore di esportazione CSV
+csv_export_delimiter_info#:#Modifica il delimitatore predefinito per le esportazioni CSV.

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 $id = 'xvid';
 
 // code version; must be changed for all code changes
-$version = "2.6.5";
+$version = "2.6.6";
 
 // ilias min and max version; must always reflect the versions that should
 // run with the plugin

--- a/sql/dbupdate.php
+++ b/sql/dbupdate.php
@@ -186,7 +186,7 @@ if(!$ilDB->tableExists('rep_robj_xvid_question'))
 			'length' => '4',
 			'notnull' => true
 		)
-	);	
+	);
 	$ilDB->createTable('rep_robj_xvid_question', $fields);
 	$ilDB->addPrimaryKey('rep_robj_xvid_question', array('question_id'));
 	$ilDB->createSequence('rep_robj_xvid_question');
@@ -413,15 +413,15 @@ if($ilDB->tableExists('rep_robj_xvid_question'))
 			)
 		);
 	}
-	
+
 	$res = $ilDB->queryF('SELECT comment_id FROM rep_robj_xvid_comments WHERE repeat_question = %s',
 		array('integer'), array(1));
-	
+
 	while($row = $ilDB->fetchAssoc($res))
 	{
 		$comment_ids[] = $row['comment_id'];
 	}
-		
+
 	$ilDB->manipulateF('
 	UPDATE rep_robj_xvid_question 
 	SET rep_robj_xvid_question.repeat_question = %s
@@ -520,7 +520,7 @@ if($ilDB->tableExists('rep_robj_xvid_comments'))
 							'notnull' => true,
 							'default' => 0));
 		}
-	} 
+	}
 ?>
 <#25>
 	<?php
@@ -1045,5 +1045,18 @@ if($ilDB->tableExists('rep_robj_xvid_question'))
                 'default' => null
             ));
     }
+}
+?>
+<#60>
+<?php
+if(!$ilDB->tableColumnExists('rep_robj_xvid_objects', 'csv_export_delimiter'))
+{
+    $ilDB->addTableColumn('rep_robj_xvid_objects', 'csv_export_delimiter',
+        array(
+            'type'    => 'text',
+            'length'  => 1,
+            'notnull' => true,
+            'default' => ";")
+    );
 }
 ?>

--- a/sql/dbupdate.php
+++ b/sql/dbupdate.php
@@ -1051,12 +1051,12 @@ if($ilDB->tableExists('rep_robj_xvid_question'))
 <?php
 if(!$ilDB->tableColumnExists('rep_robj_xvid_objects', 'csv_export_delimiter'))
 {
-    $ilDB->addTableColumn('rep_robj_xvid_objects', 'csv_export_delimiter',
-        array(
-            'type'    => 'text',
-            'length'  => 1,
-            'notnull' => true,
-            'default' => ";")
-    );
+	$ilDB->addTableColumn('rep_robj_xvid_objects', 'csv_export_delimiter',
+		array(
+			'type'    => 'text',
+			'length'  => 1,
+			'notnull' => true,
+			'default' => ";")
+	);
 }
 ?>


### PR DESCRIPTION
Solution for https://mantis.ilias.de/view.php?id=39187

Changes:
* The default is CSV export delimited is still ';' but now it can overridden in an InteractiveVideo settings. 
* I also noticed a couple of the CSV exports were missing columns so I added those.
* Whitespace got cleaned up by the editor automatically.