### PR TITLE
Fixed reference to refinery when linking InteractiveVideo in learning modules

### DIFF
--- a/classes/class.ilObjInteractiveVideoGUI.php
+++ b/classes/class.ilObjInteractiveVideoGUI.php
@@ -3807,7 +3807,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 			$ilCtrl->saveParameterByClass($class_name, 'xvid_referrer_ref_id');
             $xvid_referrer = '';
             if($get->has('xvid_referrer')){
-                $xvid_referrer = $get->retrieve('xvid_referrer', $DIC->refinery->kindlyTo()->string());
+                $xvid_referrer = $get->retrieve('xvid_referrer', $DIC->refinery()->kindlyTo()->string());
             }
 			$ilCtrl->setParameterByClass($class_name, 'xvid_referrer', urlencode($xvid_referrer));
 			$ilCtrl->redirectByClass(["ilobjplugindispatchgui", $class_name], "");
@@ -3818,7 +3818,7 @@ class ilObjInteractiveVideoGUI extends ilObjectPluginGUI implements ilDesktopIte
 			$ilCtrl->setParameterByClass($class_name, "ref_id", $ref_id);
 			$ilCtrl->saveParameterByClass($class_name, 'xvid_referrer_ref_id');
             if($get->has('xvid_referrer')){
-                $xvid_referrer = $get->retrieve('xvid_referrer', $DIC->refinery->kindlyTo()->string());
+                $xvid_referrer = $get->retrieve('xvid_referrer', $DIC->refinery()->kindlyTo()->string());
             }
 			$ilCtrl->setParameterByClass($class_name, 'xvid_referrer', urlencode($xvid_referrer));
 			$ilCtrl->redirectByClass(["ilobjplugindispatchgui", $class_name], "infoScreen");


### PR DESCRIPTION
Right now when linking an interactive video in a learning module you get this error:

```
Whoops\Exception\ErrorException thrown with message "Undefined property: ILIAS\DI\Container::$refinery"

Stacktrace:
#2 Whoops\Exception\ErrorException in /var/www/html/ilias/Customizing/global/plugins/Services/Repository/RepositoryObject/InteractiveVideo/classes/class.ilObjInteractiveVideoGUI.php:3824
#1 ilErrorHandling:handlePreWhoops in /var/www/html/ilias/Customizing/global/plugins/Services/Repository/RepositoryObject/InteractiveVideo/classes/class.ilObjInteractiveVideoGUI.php:3824
#0 ilObjInteractiveVideoGUI:_goto in /var/www/html/ilias/goto.php:219
```

I fixed the undefined property reference to use the function name for `refinery`.