### PR TITLE
Fixes #39935

### DIFF
--- a/VideoSources/core/MediaObject/class.ilInteractiveVideoMediaObject.php
+++ b/VideoSources/core/MediaObject/class.ilInteractiveVideoMediaObject.php
@@ -88,10 +88,12 @@ class ilInteractiveVideoMediaObject implements ilInteractiveVideoSource
 	 */
 	public function doUpdateVideoSource($obj_id)
 	{
-		$file = $_FILES['video_file'];
-		if($file['error'] == 0 && $this->import_file_name == '')
+		if (isset($_FILES['video_file']))
 		{
-			$this->uploadVideoFile($obj_id);
+			$file = $_FILES['video_file'];
+			if ($file['error'] == 0 && $this->import_file_name == '') {
+				$this->uploadVideoFile($obj_id);
+			}
 		}
 	}
 
@@ -382,7 +384,7 @@ class ilInteractiveVideoMediaObject implements ilInteractiveVideoSource
 			$mob->setDescription($format);
 			$media_item->setHAlign("Left");
 
-			ilUtil::renameExecutables($mob_dir);
+			ilFileUtils::renameExecutables($mob_dir);
 
 			$mob->update();
 

--- a/classes/class.ilInteractiveVideoFFmpeg.php
+++ b/classes/class.ilInteractiveVideoFFmpeg.php
@@ -147,10 +147,10 @@ class ilInteractiveVideoFFmpeg extends ilFFmpeg
 			{
 				$file_extension = $clean_extension[0];
 			}
-			$path_org = preg_split('/\?/', $path_org);
-			if(is_array($path_org) && count($path_org) > 1)
+			$clean_path_org = preg_split('/\?/', $path_org);
+			if(is_array($clean_path_org) && count($clean_path_org) > 1)
 			{
-				$path_org = $path_org[0];
+				$path_org = $clean_path_org[0];
 			}
 		}
 		$clean_name		= $comment_id .'.' . $file_extension;


### PR DESCRIPTION
Adding a check for 'video_file' existence when InteractiveVideo is imported, because that array key doesn't exist when imported.

Also fixed `renameExecutables` static class and using a separate variable for handling ffmpeg thumbnail file path (this was causing an error when the import included a thumbnail), using a separate variable worked like the extension code above it.

Bug: https://mantis.ilias.de/view.php?id=39935