### PR TITLE
Fix issue with username lookup for comments from deleted accounts

### DIFF
--- a/classes/class.ilObjComment.php
+++ b/classes/class.ilObjComment.php
@@ -357,6 +357,9 @@ class ilObjComment
 				{
 					self::$user_name_cache[$user_id] = '[' . $user->getLogin() . ']';
 				}
+			} else {
+				global $lng;
+				self::$user_name_cache[$user_id] = '[' . $lng->txt('deleted') . ']';
 			}
 		}
 

--- a/classes/class.ilObjComment.php
+++ b/classes/class.ilObjComment.php
@@ -342,22 +342,22 @@ class ilObjComment
 	}
 
 	public static function lookupUsername(int $user_id) : string
-    {
+	{
 		if(!array_key_exists($user_id, self::$user_name_cache))
 		{
-            $user_obj_exists = ilObjUser::_exists($user_id, false, 'usr');
-            $user_has_login = ilObjUser::_lookupLogin($user_id);
-            if($user_obj_exists && $user_has_login) {
-                $user = new ilObjUser($user_id);
-                if($user->hasPublicProfile())
-                {
-                    self::$user_name_cache[$user_id] = $user->getFirstname() . ' ' . $user->getLastname();
-                }
-                else
-                {
-                    self::$user_name_cache[$user_id] = '[' . $user->getLogin() . ']';
-                }
-            }
+			$user_obj_exists = ilObjUser::_exists($user_id, false, 'usr');
+			$user_has_login = ilObjUser::_lookupLogin($user_id);
+			if($user_obj_exists && $user_has_login) {
+				$user = new ilObjUser($user_id);
+				if($user->hasPublicProfile())
+				{
+					self::$user_name_cache[$user_id] = $user->getFirstname() . ' ' . $user->getLastname();
+				}
+				else
+				{
+					self::$user_name_cache[$user_id] = '[' . $user->getLogin() . ']';
+				}
+			}
 		}
 
 		return self::$user_name_cache[$user_id];


### PR DESCRIPTION
Ignoring the whitespace changes I added to put my commit in line with how the latest commits seem to be formatted, this only adds a fallback lookup to the translated value 'deleted' IFF trying to lookup a username for a comment, but the user does not exist (or doesn't have a login) anymore.

This fixes a PHP whoops exception that stops InteractiveVideo objects from being opened when there are comments from deleted accounts.

## To test and reproduce
- Create an InteractiveVideo object
- Create and login with temporary account
- Leave comment with temporary account
- Logout and delete temporary account
- Login with normal account and try to open InteractiveVideo object
  -> Throws exception about failed array key lookup (original) matching line 363

## Potential Improvements
- Currently this looks up the 'deleted' phrase from ILIAS common translation as a fallback when no account was found. Maybe this could be added to the plugins localization instead.